### PR TITLE
Support Node >=10.0.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,22 @@
+name: test
+on: [push, pull_request]
+env:
+  CI: true
+jobs:
+  test:
+    name: "Test on Node.js ${{ matrix.node-version }}"
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [13, 14]
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: setup Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Install
+        run: npm install
+      - name: Test
+        run: npm test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [13, 14]
+        node-version: [10, 12, 13, 14]
     steps:
       - name: checkout
         uses: actions/checkout@v2

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "CSP-style channel library using ES7 async/await keywords",
   "main": "./lib/index.js",
   "engines": {
-    "node": ">=13.0.0"
+    "node": ">=10.0.0"
   },
   "scripts": {
     "test": "mocha"

--- a/test/index.js
+++ b/test/index.js
@@ -459,6 +459,7 @@ describe('channels', () => {
         close(b)
         close(c)
       })
+      .then(() => sleep(0))
       .then(() => assert.equal(merged.isClosed, true))
       .then(cb)
     })


### PR DESCRIPTION
I'm a huge fan of your library and have built a massive [transformation library](https://github.com/sunesimonsen/transformation) on top of it. But your recent changes has cut Node v10 compatibility and as far as I can tell for no reason. I hope you would be open to allowing Node 10 to be supported again.

Goes on top of https://github.com/bbarr/medium/pull/17

Test result https://github.com/sunesimonsen/medium/actions/runs/356361594